### PR TITLE
Add item durability

### DIFF
--- a/entities/entities/rvr_dropped_item/init.lua
+++ b/entities/entities/rvr_dropped_item/init.lua
@@ -48,7 +48,7 @@ function ENT:Setup( item, count )
     self:SetItemDisplayName( itemData.displayName )
     if itemData.model then
         self:SetModel( itemData.model )
-    elseif item.swep then
+    elseif itemData.swep then
         local wep = weapons.Get( itemData.swep )
         if wep.Model then
             self:SetModel( wep.Model )

--- a/entities/entities/rvr_dropped_item/init.lua
+++ b/entities/entities/rvr_dropped_item/init.lua
@@ -41,10 +41,19 @@ end
 
 -- Set dropped item information
 function ENT:Setup( item, count )
+    local itemData = RVR.Items.getItemData( item.type )
+
     self:SetAmount( count )
-    self:SetItemType( item.type )
-    self:SetItemDisplayName( item.displayName )
-    self:SetModel( item.model )
+    self:SetItemType( itemData.type )
+    self:SetItemDisplayName( itemData.displayName )
+    if itemData.model then
+        self:SetModel( itemData.model )
+    elseif item.swep then
+        local wep = weapons.Get( itemData.swep )
+        if wep.Model then
+            self:SetModel( wep.Model )
+        end
+    end
 
     self.item = item
 end

--- a/gamemode/modules/inventory/cl_itemslot.lua
+++ b/gamemode/modules/inventory/cl_itemslot.lua
@@ -29,6 +29,29 @@ function PANEL:Init()
         self:SetPos( pw - w - 13, ph - h - 5 )
     end
 
+    self.itemDurabilityBar = vgui.Create( "DPanel", self )
+
+    function self.itemDurabilityBar:PerformLayout()
+        local w, h = self:GetParent():GetSize()
+        self:SetSize( w * 0.8, 3 )
+        self:SetPos( w * 0.1, h * 0.9 )
+    end
+
+    local this = self
+
+    function self.itemDurabilityBar:Paint( w, h )
+        if not this.item then return end
+        if not this.item.hasDurability then return end
+
+        surface.SetDrawColor( 50, 50, 50 )
+        surface.DrawRect( 0, 0, w, h )
+        local durabilityProgress = this.item.durability / this.item.maxDurability
+        local color = HSVToColor( durabilityProgress * 120, 1, 1 )
+
+        surface.SetDrawColor( color )
+        surface.DrawRect( 0, 0, durabilityProgress * ( w - 1 ), h - 1 )
+    end
+
     self.toolTipPanel = vgui.Create( "RVR_ItemTooltip" )
     self.toolTipPanel:Hide()
 end

--- a/gamemode/modules/inventory/sv_inventory.lua
+++ b/gamemode/modules/inventory/sv_inventory.lua
@@ -239,6 +239,25 @@ function inv.getSelectedItem( ply )
     return itemData.item, itemData.count
 end
 
+local function addDurabilityFuncs( wep, instance, itemData )
+    function wep:LoseDurability()
+        local halfRange = ( itemData.durabilityUseRandomRange or 0 ) * 0.5
+        local damage = itemData.durabilityUse + math.random( -halfRange, halfRange )
+
+        instance.durability = math.Clamp( instance.durability - damage, 0, itemData.maxDurability )
+
+        local ply = self.Owner
+        local hotbarSelected = ply.RVR_Inventory.HotbarSelected
+
+        if instance.durability <= 0 then
+            inv.consumeInSlot( ply, hotbarSelected, 1 )
+        else
+            local slotData = inv.getSlot( ply, hotbarSelected )
+            inv.notifyItemSlotChange( { ply }, ply, hotbarSelected, slotData )
+        end
+    end
+end
+
 function inv.setSelectedItem( ply, idx )
     local config = GAMEMODE.Config.Inventory
     if not ply.RVR_Inventory then return end
@@ -258,6 +277,10 @@ function inv.setSelectedItem( ply, idx )
 
         if itemData.swep then
             wep = ply:Give( itemData.swep )
+
+            if itemData.hasDurability then
+                addDurabilityFuncs( wep, itemSlotData.item, itemData )
+            end
         else
             wep = ply:Give( "rvr_held_item" )
             wep:SetItemData( itemData )
@@ -374,7 +397,7 @@ function inv.dropItem( ply, position, count )
     local droppedItem = ents.Create( "rvr_dropped_item" )
     if not IsValid( droppedItem ) then return end
     droppedItem:SetPos( ply:GetShootPos() + Angle( 0, ply:EyeAngles().yaw, 0 ):Forward() * 20 )
-    droppedItem:Setup( RVR.Items.getItemData( itemData.item.type ), count )
+    droppedItem:Setup( itemData.item, count )
     droppedItem:Spawn()
 
     return droppedItem

--- a/gamemode/modules/inventory/sv_inventory_commands.lua
+++ b/gamemode/modules/inventory/sv_inventory_commands.lua
@@ -3,7 +3,9 @@ local function giveItem( caller, target, item, count )
         return "Cannot give less than 1 item, what are you expecting to happen?"
     end
 
-    local success, amount = RVR.Inventory.attemptPickupItem( target, item, count )
+    local instance = RVR.Items.getItemInstance( item.type )
+
+    local success, amount = RVR.Inventory.attemptPickupItem( target, instance, count )
     if success then return end
 
     if amount == 0 then

--- a/gamemode/modules/items/README.md
+++ b/gamemode/modules/items/README.md
@@ -26,3 +26,7 @@ Creates a simple table for an item instance, currently just `{ type = itemType }
 - `water` - (int) Water value of this item, requires consumable
 - `health` - (int) Health value of this item, requires consumable
 - `onConsume` - (function) What do when consume
+- `hasDurability` - (bool) Does this item have durability, if defined, `maxDurability` and `durabilityUse` are also required
+- `maxDurability` - (int) Maximum durability, default for item spawn
+- `durabilityUse` - (int) How much durability to use when `wep:LoseDurability()` is used
+- `durabilityUseRandomRange` - (int) Optional random addition to durabilityUse on damage, by adding random between `-range/2` and `range`

--- a/gamemode/modules/items/sh_items.lua
+++ b/gamemode/modules/items/sh_items.lua
@@ -82,19 +82,6 @@ items.items = {
         viewModelOffset = Vector( -2, 5, -9 ),
         viewModelAng = Angle( 0, -15, 0 ),
     },
-    {
-        type = "testwep",
-        displayName = "eee",
-        description = "ijhaiu",
-        stackable = false,
-        swep = "weapon_ar2",
-        model = "models/weapons/w_irifle.mdl",
-        icon = "materials/rvr/items/water_bottle.png",
-        hasDurability = true,
-        maxDurability = 1000,
-        durabilityUse = 50,
-        durabilityUseRandomRange = 50,
-    }
 }
 
 local config = GM.Config.Hunger

--- a/gamemode/modules/items/sh_items.lua
+++ b/gamemode/modules/items/sh_items.lua
@@ -9,13 +9,20 @@ end
 
 -- Wrapper for now, allows adding metadata to item instances later
 function items.getItemInstance( itemType )
-    if not items.getItemData( itemType ) then
+    local itemData = items.getItemData( itemType )
+    if not itemData then
         error( "Item type " .. itemType .. " does not exist" )
     end
 
-    return {
+    local instance = {
         type = itemType
     }
+
+    if itemData.hasDurability then
+        instance.durability = itemData.maxDurability
+    end
+
+    return instance
 end
 
 -- Item structure in README
@@ -75,6 +82,19 @@ items.items = {
         viewModelOffset = Vector( -2, 5, -9 ),
         viewModelAng = Angle( 0, -15, 0 ),
     },
+    {
+        type = "testwep",
+        displayName = "eee",
+        description = "ijhaiu",
+        stackable = false,
+        swep = "weapon_ar2",
+        model = "models/weapons/w_irifle.mdl",
+        icon = "materials/rvr/items/water_bottle.png",
+        hasDurability = true,
+        maxDurability = 1000,
+        durabilityUse = 50,
+        durabilityUseRandomRange = 50,
+    }
 }
 
 local config = GM.Config.Hunger
@@ -118,5 +138,8 @@ for k, item in pairs( items.items ) do
 end
 
 for _, item in pairs( items.items ) do
-    util.PrecacheModel( item.model )
+    if item.model then
+        util.PrecacheModel( item.model )
+    end
+    item.maxCount = item.maxCount or 1
 end


### PR DESCRIPTION
An item can define `hasDurability`, `durabilityUse`, `maxDurability` and `durabilityUseRandomRange`.
Adds a durability bar on item slots
Defines a `LoseDurability()` function on the weapon when it is spawned if the item it is assigned to has durability.
The SWEP is expected to call this whenever used in some way that would damage it.