### PR TITLE
Item networking

### DIFF
--- a/gamemode/modules/inventory/cl_inventory.lua
+++ b/gamemode/modules/inventory/cl_inventory.lua
@@ -8,12 +8,12 @@ include( "cl_boxinventory.lua" )
 local cursorSlotSize = 60
 
 net.Receive( "RVR_Inventory_Open", function()
-    local inventory = net.ReadTable()
+    local inventory = inv.fromInventoryData( net.ReadTable() )
     local isSelf = net.ReadBool()
     local plyInventory = inventory
 
     if not isSelf then
-        plyInventory = net.ReadTable()
+        plyInventory = inv.fromInventoryData( net.ReadTable() )
     end
 
     -- Update hotbar slots for any inventory open
@@ -62,6 +62,7 @@ net.Receive( "RVR_Inventory_UpdateSlot", function()
 
     if hasSlotData then
         slotData = net.ReadTable()
+        inv.setupItemMeta( slotData.item )
     end
 
     -- Update to the LocalPlayers cursor slot
@@ -124,6 +125,21 @@ hook.Add( "PlayerBindPress", "RVR_Inventory", function( _, bind, pressed )
         return true
     end
 end )
+
+function inv.fromInventoryData( inventory )
+    for k, v in pairs( inventory.Inventory ) do
+        inv.setupItemMeta( v.item )
+    end
+
+    return inventory
+end
+
+function inv.setupItemMeta( item )
+    local mt = { __index = RVR.Items.getItemData( item.type ) }
+    setmetatable( item, mt )
+
+    return item
+end
 
 function inv.closeInventory()
     if inv.openInventory then

--- a/gamemode/modules/inventory/cl_pickup_popup.lua
+++ b/gamemode/modules/inventory/cl_pickup_popup.lua
@@ -16,7 +16,8 @@ local popupItemMaterial = Material( "rvr/backgrounds/dark_slot_background.png" )
 local brown = Color( 91, 56, 34 )
 
 net.Receive( "RVR_Inventory_OnPickup", function()
-    local itemData = net.ReadTable()
+    local itemType = net.ReadString()
+    local itemData = RVR.Items.getItemData( itemType )
     local count = net.ReadUInt( 16 )
 
     table.insert( inv.pickupPopups, 1, {

--- a/gamemode/modules/inventory/sv_inventory_interaction.lua
+++ b/gamemode/modules/inventory/sv_inventory_interaction.lua
@@ -13,14 +13,6 @@ util.AddNetworkString( "RVR_Inventory_DropItem" )
 util.AddNetworkString( "RVR_Inventory_RequestPlayerUpdate" )
 util.AddNetworkString( "RVR_Inventory_SetHotbarSelected" )
 
-local function removeFunctions( tab )
-    for k, v in pairs( tab ) do
-        if type( v ) == "function" then
-            tab[k] = nil
-        end
-    end
-end
-
 local function getSendableInventory( ent, inventory, isPlayerUpdate )
     local config = GAMEMODE.Config.Inventory
 
@@ -37,22 +29,14 @@ local function getSendableInventory( ent, inventory, isPlayerUpdate )
         end
     end
 
-    for k, v in pairs( inventory.Inventory ) do
-        v.item = table.Merge( v.item, RVR.Items.getItemData( v.item.type ) )
-        removeFunctions( v.item )
-    end
-
     inventory.Ent = ent
 
     return inventory
 end
 
 function inv.notifyItemPickup( ply, item, count )
-    local itemTable = table.Copy( RVR.Items.getItemData( item.type ) )
-    removeFunctions( itemTable )
-
     net.Start( "RVR_Inventory_OnPickup" )
-        net.WriteTable( itemTable )
+        net.WriteString( item.type )
         net.WriteUInt( count, 16 )
     net.Send( ply )
 end
@@ -66,10 +50,7 @@ function inv.notifyItemSlotChange( plys, ent, slotNum, slotData )
         net.WriteBool( tobool( slotData ) )
 
         if slotData then
-            local data = table.Copy( slotData )
-            table.Merge( data.item, RVR.Items.getItemData( data.item.type ) )
-            removeFunctions( data.item )
-            net.WriteTable( data )
+            net.WriteTable( slotData )
         end
     net.Send( plys )
 end


### PR DESCRIPTION
Changed all item related networking to only send instance information, rather than full item data.
Client side then uses metatables to fill in the constant data for items.
Reduces net traffic and prepares for item OO overhaul.

Tested and working.